### PR TITLE
GenericMessageProcessor: Assets handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.wire</groupId>
     <artifactId>xenon</artifactId>
-    <version>1.0.7</version>
+    <version>1.1.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/wire/xenon/MessageHandlerBase.java
+++ b/src/main/java/com/wire/xenon/MessageHandlerBase.java
@@ -270,4 +270,24 @@ public abstract class MessageHandlerBase {
             Logger.error("validatePreKeys: bot: %s %s", client.getId(), e);
         }
     }
+
+    public void onPhotoPreview(WireClient client, PhotoPreviewMessage msg) {
+
+    }
+
+    public void onAssetData(WireClient client, RemoteMessage msg) {
+
+    }
+
+    public void onFilePreview(WireClient client, FilePreviewMessage msg) {
+
+    }
+
+    public void onAudioPreview(WireClient client, AudioPreviewMessage msg) {
+
+    }
+
+    public void onVideoPreview(WireClient client, VideoPreviewMessage msg) {
+
+    }
 }

--- a/src/main/java/com/wire/xenon/MessageResourceBase.java
+++ b/src/main/java/com/wire/xenon/MessageResourceBase.java
@@ -35,7 +35,8 @@ public abstract class MessageResourceBase {
 
                 Messages.GenericMessage message = decrypt(client, payload);
 
-                boolean process = processor.process(from,
+                boolean process = processor.process(eventId,
+                        from,
                         data.sender,
                         payload.convId,
                         payload.time,
@@ -139,9 +140,9 @@ public abstract class MessageResourceBase {
         }
     }
 
-    private SystemMessage getSystemMessage(UUID messageId, Payload payload) {
+    private SystemMessage getSystemMessage(UUID eventId, Payload payload) {
         SystemMessage systemMessage = new SystemMessage();
-        systemMessage.id = messageId;
+        systemMessage.id = eventId;
         systemMessage.from = payload.from;
         systemMessage.time = payload.time;
         systemMessage.type = payload.type;

--- a/src/main/java/com/wire/xenon/MessageResourceBase.java
+++ b/src/main/java/com/wire/xenon/MessageResourceBase.java
@@ -8,6 +8,7 @@ import com.wire.xenon.backend.models.Conversation;
 import com.wire.xenon.backend.models.Member;
 import com.wire.xenon.backend.models.Payload;
 import com.wire.xenon.backend.models.SystemMessage;
+import com.wire.xenon.models.MessageBase;
 import com.wire.xenon.tools.Logger;
 
 import java.util.Base64;
@@ -33,21 +34,19 @@ public abstract class MessageResourceBase {
 
                 GenericMessageProcessor processor = new GenericMessageProcessor(client, handler);
 
-                Messages.GenericMessage message = decrypt(client, payload);
+                Messages.GenericMessage genericMessage = decrypt(client, payload);
 
-                boolean process = processor.process(eventId,
-                        from,
-                        data.sender,
-                        payload.convId,
-                        payload.time,
-                        message);
+                final UUID messageId = UUID.fromString(genericMessage.getMessageId());
+                MessageBase msgBase = new MessageBase(eventId, messageId, payload.convId, data.sender, from, payload.time);
 
+                boolean process = processor.process(msgBase, genericMessage);
+
+                // todo remove this
                 if (process) {
-                    UUID messageId = UUID.fromString(message.getMessageId());
                     processor.cleanUp(messageId);
                 }
 
-                handler.onEvent(client, from, message);
+                handler.onEvent(client, from, genericMessage);
                 break;
             case "conversation.member-join":
                 Logger.debug("conversation.member-join: bot: %s", botId);

--- a/src/main/java/com/wire/xenon/assets/FileAsset.java
+++ b/src/main/java/com/wire/xenon/assets/FileAsset.java
@@ -36,6 +36,10 @@ public class FileAsset extends AssetBase {
         super(messageId, mimeType, bytes);
     }
 
+    public FileAsset(UUID messageId, String mimeType) {
+        super(messageId, mimeType);
+    }
+
     public FileAsset(String assetKey, String assetToken, byte[] sha256, byte[] otrKey, UUID messageId) {
         super(messageId, null);
         this.assetKey = assetKey;

--- a/src/main/java/com/wire/xenon/backend/GenericMessageProcessor.java
+++ b/src/main/java/com/wire/xenon/backend/GenericMessageProcessor.java
@@ -28,9 +28,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- *
- */
 public class GenericMessageProcessor {
     private final static ConcurrentHashMap<UUID, Messages.Asset.Original> originals = new ConcurrentHashMap<>();
     private final static ConcurrentHashMap<UUID, Messages.Asset.RemoteData> remotes = new ConcurrentHashMap<>();
@@ -48,9 +45,13 @@ public class GenericMessageProcessor {
         originals.remove(messageId);
     }
 
-    public boolean process(UUID eventId, UUID from, String clientId, UUID convId, String time,
-                           Messages.GenericMessage generic) {
-        UUID messageId = UUID.fromString(generic.getMessageId());
+    public boolean process(MessageBase msgBase, Messages.GenericMessage generic) {
+        final UUID messageId = msgBase.getMessageId();
+        final UUID conversationId = msgBase.getConversationId();
+        final String clientId = msgBase.getClientId();
+        final UUID eventId = msgBase.getEventId();
+        final String time = msgBase.getTime();
+        final UUID from = msgBase.getUserId();
 
         Messages.Asset asset = null;
 
@@ -65,9 +66,7 @@ public class GenericMessageProcessor {
             Messages.Ephemeral ephemeral = generic.getEphemeral();
 
             if (ephemeral.hasText() && ephemeral.getText().hasContent()) {
-                EphemeralTextMessage msg = new EphemeralTextMessage(messageId, convId, clientId, from);
-                msg.setTime(time);
-                msg.setEventId(eventId);
+                EphemeralTextMessage msg = new EphemeralTextMessage(msgBase);
                 msg.setExpireAfterMillis(ephemeral.getExpireAfterMillis());
                 msg.setText(ephemeral.getText().getContent());
                 if (ephemeral.getText().hasQuote()) {
@@ -89,11 +88,9 @@ public class GenericMessageProcessor {
         // Edit message
         if (generic.hasEdited() && generic.getEdited().hasText()) {
             Messages.MessageEdit edited = generic.getEdited();
-            EditedTextMessage msg = new EditedTextMessage(messageId, convId, clientId, from);
+            EditedTextMessage msg = new EditedTextMessage(msgBase);
             msg.setReplacingMessageId(UUID.fromString(edited.getReplacingMessageId()));
             msg.setText(edited.getText().getContent());
-            msg.setTime(time);
-            msg.setEventId(eventId);
 
             for (Messages.Mention mention : edited.getText().getMentionsList())
                 msg.addMention(mention.getUserId(), mention.getStart(), mention.getLength());
@@ -104,8 +101,7 @@ public class GenericMessageProcessor {
 
         if (generic.hasConfirmation()) {
             Messages.Confirmation confirmation = generic.getConfirmation();
-            ConfirmationMessage msg = new ConfirmationMessage(messageId, convId, clientId, from);
-            msg.setEventId(eventId);
+            ConfirmationMessage msg = new ConfirmationMessage(msgBase);
 
             return handleConfirmation(confirmation, msg, time);
         }
@@ -116,18 +112,15 @@ public class GenericMessageProcessor {
             List<Messages.LinkPreview> linkPreviewList = text.getLinkPreviewList();
 
             if (!linkPreviewList.isEmpty()) {
-                LinkPreviewMessage msg = new LinkPreviewMessage(messageId, convId, clientId, from);
-                msg.setEventId(eventId);
+                LinkPreviewMessage msg = new LinkPreviewMessage(msgBase);
                 String content = text.getContent();
 
                 return handleLinkPreview(linkPreviewList, content, msg, time);
             }
 
             if (text.hasContent()) {
-                TextMessage msg = new TextMessage(messageId, convId, clientId, from);
+                TextMessage msg = new TextMessage(msgBase);
                 msg.setText(text.getContent());
-                msg.setTime(time);
-                msg.setEventId(eventId);
 
                 if (text.hasQuote()) {
                     final String quotedMessageId = text.getQuote().getQuotedMessageId();
@@ -144,10 +137,8 @@ public class GenericMessageProcessor {
         if (generic.hasCalling()) {
             Messages.Calling calling = generic.getCalling();
             if (calling.hasContent()) {
-                CallingMessage message = new CallingMessage(messageId, convId, clientId, from);
+                CallingMessage message = new CallingMessage(msgBase);
                 message.setContent(calling.getContent());
-                message.setTime(time);
-                message.setEventId(eventId);
 
                 handler.onCalling(client, message);
             }
@@ -155,11 +146,9 @@ public class GenericMessageProcessor {
         }
 
         if (generic.hasDeleted()) {
-            DeletedTextMessage msg = new DeletedTextMessage(messageId, convId, clientId, from);
+            DeletedTextMessage msg = new DeletedTextMessage(msgBase);
             UUID delMsgId = UUID.fromString(generic.getDeleted().getMessageId());
             msg.setDeletedMessageId(delMsgId);
-            msg.setTime(time);
-            msg.setEventId(eventId);
 
             handler.onDelete(client, msg);
             return true;
@@ -167,16 +156,13 @@ public class GenericMessageProcessor {
 
         if (generic.hasReaction()) {
             Messages.Reaction reaction = generic.getReaction();
-            ReactionMessage msg = new ReactionMessage(messageId, convId, clientId, from);
-            msg.setEventId(eventId);
+            ReactionMessage msg = new ReactionMessage(msgBase);
 
             return handleReaction(reaction, msg, time);
         }
 
         if (generic.hasKnock()) {
-            PingMessage msg = new PingMessage(messageId, convId, clientId, from);
-            msg.setEventId(eventId);
-            msg.setTime(time);
+            PingMessage msg = new PingMessage(msgBase);
 
             handler.onPing(client, msg);
             return true;
@@ -196,8 +182,7 @@ public class GenericMessageProcessor {
                     asset.hasPreview());
 
             if (asset.hasPreview()) {
-                ImageMessage msg = new ImageMessage(messageId, convId, clientId, from);
-                msg.setEventId(eventId);
+                ImageMessage msg = new ImageMessage(msgBase);
 
                 handleVideoPreview(asset.getPreview(), msg, time);  //todo is this legacy?
             }
@@ -214,8 +199,7 @@ public class GenericMessageProcessor {
             Messages.Asset.Original original = originals.get(messageId);
             Messages.Asset.RemoteData remoteData = remotes.get(messageId);
 
-            MessageAssetBase base = new MessageAssetBase(messageId, convId, clientId, from);
-            base.setTime(time);
+            MessageAssetBase base = new MessageAssetBase(msgBase);
             base.fromOrigin(original);
             base.fromRemote(remoteData);
             /// --- Obsolete ---
@@ -223,81 +207,18 @@ public class GenericMessageProcessor {
             if (asset.hasOriginal()) {
                 original = asset.getOriginal();
                 if (original.hasImage()) {
-                    final PhotoPreviewMessage message = new PhotoPreviewMessage(
-                            messageId,
-                            convId,
-                            clientId,
-                            from,
-                            original.getMimeType(),
-                            original.getSize(),
-                            original.getName(),
-                            original.getImage().getWidth(),
-                            original.getImage().getHeight());
-                    message.setEventId(eventId);
-                    message.setTime(time);
-
-                    handler.onPhotoPreview(client, message);
+                    handler.onPhotoPreview(client, new PhotoPreviewMessage(msgBase, original));
                 } else if (original.hasAudio()) {
-                    final AudioPreviewMessage message = new AudioPreviewMessage(
-                            messageId,
-                            convId,
-                            clientId,
-                            from,
-                            original.getMimeType(),
-                            original.getSize(),
-                            original.getName(),
-                            original.getAudio().getDurationInMillis(),
-                            original.getAudio().getNormalizedLoudness().toByteArray());
-                    message.setEventId(eventId);
-                    message.setTime(time);
-
-                    handler.onAudioPreview(client, message);
+                    handler.onAudioPreview(client, new AudioPreviewMessage(msgBase, original));
                 } else if (original.hasVideo()) {
-                    final VideoPreviewMessage message = new VideoPreviewMessage(
-                            messageId,
-                            convId,
-                            clientId,
-                            from,
-                            original.getMimeType(),
-                            original.getSize(),
-                            original.getName(),
-                            original.getVideo().getWidth(),
-                            original.getVideo().getHeight(),
-                            original.getVideo().getDurationInMillis());
-                    message.setEventId(eventId);
-                    message.setTime(time);
-
-                    handler.onVideoPreview(client, message);
+                    handler.onVideoPreview(client, new VideoPreviewMessage(msgBase, original));
                 } else {
-                    final FilePreviewMessage message = new FilePreviewMessage(
-                            messageId,
-                            convId,
-                            clientId,
-                            from,
-                            original.getMimeType(),
-                            original.getSize(),
-                            original.hasName() ? original.getName() : null);
-                    message.setEventId(eventId);
-                    message.setTime(time);
-
-                    handler.onFilePreview(client, message);
+                    handler.onFilePreview(client, new FilePreviewMessage(msgBase, original));
                 }
             }
 
             if (asset.hasUploaded()) {
-                final Messages.Asset.RemoteData uploaded = asset.getUploaded();
-                final RemoteMessage message = new RemoteMessage(messageId,
-                        convId,
-                        clientId,
-                        from,
-                        uploaded.getAssetId(),
-                        uploaded.getAssetToken(),
-                        uploaded.getOtrKey().toByteArray(),
-                        uploaded.getSha256().toByteArray());
-                message.setEventId(eventId);
-                message.setTime(time);
-
-                handler.onAssetData(client, message);
+                handler.onAssetData(client, new RemoteMessage(msgBase, asset.getUploaded()));
             }
 
             /// --- Obsolete ---
@@ -336,7 +257,6 @@ public class GenericMessageProcessor {
         msg.setType(type.getNumber() == Messages.Confirmation.Type.DELIVERED_VALUE
                 ? ConfirmationMessage.Type.DELIVERED
                 : ConfirmationMessage.Type.READ);
-        msg.setTime(time);
 
         handler.onConfirmation(client, msg);
         return true;
@@ -349,7 +269,6 @@ public class GenericMessageProcessor {
             msg.fromOrigin(image.getOriginal());
             msg.fromRemote(image.getUploaded());
 
-            msg.setTime(time);
             msg.setHeight(image.getOriginal().getImage().getHeight());
             msg.setWidth(image.getOriginal().getImage().getWidth());
 
@@ -368,7 +287,6 @@ public class GenericMessageProcessor {
         if (reaction.hasEmoji()) {
             msg.setEmoji(reaction.getEmoji());
             msg.setReactionMessageId(UUID.fromString(reaction.getMessageId()));
-            msg.setTime(time);
 
             handler.onReaction(client, msg);
         }
@@ -377,7 +295,6 @@ public class GenericMessageProcessor {
 
     private void handleVideoPreview(Messages.Asset.Preview preview, ImageMessage msg, String time) {
         if (preview.hasRemote()) {
-            msg.setTime(time);
             msg.fromRemote(preview.getRemote());
 
             msg.setHeight(preview.getImage().getHeight());

--- a/src/main/java/com/wire/xenon/models/AssetKey.java
+++ b/src/main/java/com/wire/xenon/models/AssetKey.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class AssetKey {
-    public String key;
+    public String id;
     public String token;
     public String expires;
 }

--- a/src/main/java/com/wire/xenon/models/AttachmentMessage.java
+++ b/src/main/java/com/wire/xenon/models/AttachmentMessage.java
@@ -25,13 +25,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.UUID;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Deprecated
 public class AttachmentMessage extends MessageAssetBase {
     @JsonCreator
-    public AttachmentMessage(@JsonProperty("messageId") UUID messageId,
+    public AttachmentMessage(@JsonProperty("eventId") UUID eventId,
+                             @JsonProperty("messageId") UUID messageId,
                              @JsonProperty("conversationId") UUID convId,
                              @JsonProperty("clientId") String clientId,
-                             @JsonProperty("userId") UUID userId) {
-        super(messageId, convId, clientId, userId);
+                             @JsonProperty("userId") UUID userId,
+                             @JsonProperty("time") String time) {
+        super(eventId, messageId, convId, clientId, userId, time);
     }
 
     public AttachmentMessage(MessageAssetBase base) {

--- a/src/main/java/com/wire/xenon/models/AudioMessage.java
+++ b/src/main/java/com/wire/xenon/models/AudioMessage.java
@@ -26,6 +26,7 @@ import com.waz.model.Messages;
 import java.util.UUID;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Deprecated
 public class AudioMessage extends MessageAssetBase {
     @JsonProperty
     private long duration;
@@ -34,11 +35,13 @@ public class AudioMessage extends MessageAssetBase {
     private byte[] levels;
 
     @JsonCreator
-    public AudioMessage(@JsonProperty("messageId") UUID messageId,
+    public AudioMessage(@JsonProperty("eventId") UUID eventId,
+                        @JsonProperty("messageId") UUID messageId,
                         @JsonProperty("conversationId") UUID convId,
                         @JsonProperty("clientId") String clientId,
-                        @JsonProperty("userId") UUID userId) {
-        super(messageId, convId, clientId, userId);
+                        @JsonProperty("userId") UUID userId,
+                        @JsonProperty("time") String time) {
+        super(eventId, messageId, convId, clientId, userId, time);
     }
 
     public AudioMessage(MessageAssetBase base, Messages.Asset.AudioMetaData audio) {

--- a/src/main/java/com/wire/xenon/models/AudioPreviewMessage.java
+++ b/src/main/java/com/wire/xenon/models/AudioPreviewMessage.java
@@ -21,6 +21,7 @@ package com.wire.xenon.models;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.waz.model.Messages;
 
 import java.util.UUID;
 
@@ -33,16 +34,18 @@ public class AudioPreviewMessage extends OriginMessage {
     private byte[] levels;
 
     @JsonCreator
-    public AudioPreviewMessage(@JsonProperty("messageId") UUID messageId,
+    public AudioPreviewMessage(@JsonProperty("eventId") UUID eventId,
+                               @JsonProperty("messageId") UUID messageId,
                                @JsonProperty("conversationId") UUID convId,
                                @JsonProperty("clientId") String clientId,
                                @JsonProperty("userId") UUID userId,
+                               @JsonProperty("time") String time,
                                @JsonProperty("mimeType") String mimeType,
                                @JsonProperty("size") long size,
                                @JsonProperty("name") String name,
                                @JsonProperty("duration") long duration,
                                @JsonProperty("levels") byte[] levels) {
-        super(messageId, convId, clientId, userId);
+        super(eventId, messageId, convId, clientId, userId, time);
 
         setMimeType(mimeType);
         setName(name);
@@ -50,6 +53,16 @@ public class AudioPreviewMessage extends OriginMessage {
 
         setDuration(duration);
         setLevels(levels);
+    }
+
+    public AudioPreviewMessage(MessageBase msg, Messages.Asset.Original original) {
+        super(msg);
+
+        setMimeType(original.getMimeType());
+        setSize(original.getSize());
+        setName(original.getName());
+        setDuration(original.getAudio().getDurationInMillis());
+        setLevels(original.getAudio().getNormalizedLoudness().toByteArray());
     }
 
     public long getDuration() {

--- a/src/main/java/com/wire/xenon/models/AudioPreviewMessage.java
+++ b/src/main/java/com/wire/xenon/models/AudioPreviewMessage.java
@@ -1,0 +1,70 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+package com.wire.xenon.models;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AudioPreviewMessage extends OriginMessage {
+    @JsonProperty
+    private long duration;
+
+    @JsonProperty
+    private byte[] levels;
+
+    @JsonCreator
+    public AudioPreviewMessage(@JsonProperty("messageId") UUID messageId,
+                               @JsonProperty("conversationId") UUID convId,
+                               @JsonProperty("clientId") String clientId,
+                               @JsonProperty("userId") UUID userId,
+                               @JsonProperty("mimeType") String mimeType,
+                               @JsonProperty("size") long size,
+                               @JsonProperty("name") String name,
+                               @JsonProperty("duration") long duration,
+                               @JsonProperty("levels") byte[] levels) {
+        super(messageId, convId, clientId, userId);
+
+        setMimeType(mimeType);
+        setName(name);
+        setSize(size);
+
+        setDuration(duration);
+        setLevels(levels);
+    }
+
+    public long getDuration() {
+        return duration;
+    }
+
+    public void setDuration(long duration) {
+        this.duration = duration;
+    }
+
+    public byte[] getLevels() {
+        return levels;
+    }
+
+    public void setLevels(byte[] levels) {
+        this.levels = levels;
+    }
+}

--- a/src/main/java/com/wire/xenon/models/CallingMessage.java
+++ b/src/main/java/com/wire/xenon/models/CallingMessage.java
@@ -30,11 +30,17 @@ public class CallingMessage extends MessageBase {
     private String content;
 
     @JsonCreator
-    public CallingMessage(@JsonProperty("messageId") UUID messageId,
+    public CallingMessage(@JsonProperty("eventId") UUID eventId,
+                          @JsonProperty("messageId") UUID messageId,
                           @JsonProperty("conversationId") UUID convId,
                           @JsonProperty("clientId") String clientId,
-                          @JsonProperty("userId") UUID userId) {
-        super(messageId, convId, clientId, userId);
+                          @JsonProperty("userId") UUID userId,
+                          @JsonProperty("time") String time) {
+        super(eventId, messageId, convId, clientId, userId, time);
+    }
+
+    public CallingMessage(MessageBase msgBase) {
+        super(msgBase);
     }
 
     public String getContent() {

--- a/src/main/java/com/wire/xenon/models/ConfirmationMessage.java
+++ b/src/main/java/com/wire/xenon/models/ConfirmationMessage.java
@@ -32,11 +32,17 @@ public class ConfirmationMessage extends MessageBase {
     private UUID confirmationMessageId;
 
     @JsonCreator
-    public ConfirmationMessage(@JsonProperty("messageId") UUID messageId,
+    public ConfirmationMessage(@JsonProperty("eventId") UUID eventId,
+                               @JsonProperty("messageId") UUID messageId,
                                @JsonProperty("conversationId") UUID convId,
                                @JsonProperty("clientId") String clientId,
-                               @JsonProperty("userId") UUID userId) {
-        super(messageId, convId, clientId, userId);
+                               @JsonProperty("userId") UUID userId,
+                               @JsonProperty("time") String time) {
+        super(eventId, messageId, convId, clientId, userId, time);
+    }
+
+    public ConfirmationMessage(MessageBase msg) {
+        super(msg);
     }
 
     public Type getType() {

--- a/src/main/java/com/wire/xenon/models/DeletedTextMessage.java
+++ b/src/main/java/com/wire/xenon/models/DeletedTextMessage.java
@@ -30,11 +30,17 @@ public class DeletedTextMessage extends MessageBase {
     private UUID deletedMessageId;
 
     @JsonCreator
-    public DeletedTextMessage(@JsonProperty("messageId") UUID messageId,
+    public DeletedTextMessage(@JsonProperty("eventId") UUID eventId,
+                              @JsonProperty("messageId") UUID messageId,
                               @JsonProperty("conversationId") UUID convId,
                               @JsonProperty("clientId") String clientId,
-                              @JsonProperty("userId") UUID userId) {
-        super(messageId, convId, clientId, userId);
+                              @JsonProperty("userId") UUID userId,
+                              @JsonProperty("time") String time) {
+        super(eventId, messageId, convId, clientId, userId, time);
+    }
+
+    public DeletedTextMessage(MessageBase msgBase) {
+        super(msgBase);
     }
 
     public UUID getDeletedMessageId() {

--- a/src/main/java/com/wire/xenon/models/EditedTextMessage.java
+++ b/src/main/java/com/wire/xenon/models/EditedTextMessage.java
@@ -30,11 +30,17 @@ public class EditedTextMessage extends TextMessage {
     private UUID replacingMessageId;
 
     @JsonCreator
-    public EditedTextMessage(@JsonProperty("messageId") UUID messageId,
+    public EditedTextMessage(@JsonProperty("eventId") UUID eventId,
+                             @JsonProperty("messageId") UUID messageId,
                              @JsonProperty("conversationId") UUID convId,
                              @JsonProperty("clientId") String clientId,
-                             @JsonProperty("userId") UUID userId) {
-        super(messageId, convId, clientId, userId);
+                             @JsonProperty("userId") UUID userId,
+                             @JsonProperty("time") String time) {
+        super(eventId, messageId, convId, clientId, userId, time);
+    }
+
+    public EditedTextMessage(MessageBase msg) {
+        super(msg);
     }
 
     public UUID getReplacingMessageId() {

--- a/src/main/java/com/wire/xenon/models/EphemeralTextMessage.java
+++ b/src/main/java/com/wire/xenon/models/EphemeralTextMessage.java
@@ -30,11 +30,20 @@ public class EphemeralTextMessage extends TextMessage {
     private long expireAfterMillis;
 
     @JsonCreator
-    public EphemeralTextMessage(@JsonProperty("messageId") UUID messageId,
+    public EphemeralTextMessage(@JsonProperty("eventId") UUID eventId,
+                                @JsonProperty("messageId") UUID messageId,
                                 @JsonProperty("conversationId") UUID convId,
                                 @JsonProperty("clientId") String clientId,
-                                @JsonProperty("userId") UUID userId) {
-        super(messageId, convId, clientId, userId);
+                                @JsonProperty("userId") UUID userId,
+                                @JsonProperty("time") String time,
+                                @JsonProperty("expireAfterMillis") long expireAfterMillis
+    ) {
+        super(eventId, messageId, convId, clientId, userId, time);
+        this.expireAfterMillis = expireAfterMillis;
+    }
+
+    public EphemeralTextMessage(MessageBase msg) {
+        super(msg);
     }
 
     public long getExpireAfterMillis() {

--- a/src/main/java/com/wire/xenon/models/FilePreviewMessage.java
+++ b/src/main/java/com/wire/xenon/models/FilePreviewMessage.java
@@ -1,0 +1,44 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+package com.wire.xenon.models;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FilePreviewMessage extends OriginMessage {
+    @JsonCreator
+    public FilePreviewMessage(@JsonProperty("messageId") UUID messageId,
+                              @JsonProperty("conversationId") UUID convId,
+                              @JsonProperty("clientId") String clientId,
+                              @JsonProperty("userId") UUID userId,
+                              @JsonProperty("mimeType") String mimeType,
+                              @JsonProperty("size") long size,
+                              @JsonProperty("name") String name) {
+        super(messageId, convId, clientId, userId);
+
+        setMimeType(mimeType);
+        setName(name);
+        setSize(size);
+    }
+
+}

--- a/src/main/java/com/wire/xenon/models/FilePreviewMessage.java
+++ b/src/main/java/com/wire/xenon/models/FilePreviewMessage.java
@@ -21,24 +21,35 @@ package com.wire.xenon.models;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.waz.model.Messages;
 
 import java.util.UUID;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class FilePreviewMessage extends OriginMessage {
     @JsonCreator
-    public FilePreviewMessage(@JsonProperty("messageId") UUID messageId,
+    public FilePreviewMessage(@JsonProperty("eventId") UUID eventId,
+                              @JsonProperty("messageId") UUID messageId,
                               @JsonProperty("conversationId") UUID convId,
                               @JsonProperty("clientId") String clientId,
                               @JsonProperty("userId") UUID userId,
+                              @JsonProperty("time") String time,
                               @JsonProperty("mimeType") String mimeType,
                               @JsonProperty("size") long size,
                               @JsonProperty("name") String name) {
-        super(messageId, convId, clientId, userId);
+        super(eventId, messageId, convId, clientId, userId, time);
 
         setMimeType(mimeType);
         setName(name);
         setSize(size);
     }
 
+
+    public FilePreviewMessage(MessageBase msg, Messages.Asset.Original original) {
+        super(msg);
+
+        setMimeType(original.getMimeType());
+        setSize(original.getSize());
+        setName(original.getName());
+    }
 }

--- a/src/main/java/com/wire/xenon/models/ImageMessage.java
+++ b/src/main/java/com/wire/xenon/models/ImageMessage.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Deprecated
 public class ImageMessage extends MessageAssetBase {
     @JsonProperty
     private int height;
@@ -35,10 +36,12 @@ public class ImageMessage extends MessageAssetBase {
     private int width;
 
     @JsonCreator
-    public ImageMessage(@JsonProperty("messageId") UUID messageId,
+    public ImageMessage(@JsonProperty("eventId") UUID eventId,
+                        @JsonProperty("messageId") UUID messageId,
                         @JsonProperty("conversationId") UUID convId,
                         @JsonProperty("clientId") String clientId,
                         @JsonProperty("userId") UUID userId,
+                        @JsonProperty("time") String time,
                         @JsonProperty("assetKey") String assetKey,
                         @JsonProperty("assetToken") String assetToken,
                         @JsonProperty("otrKey") byte[] otrKey,
@@ -46,7 +49,7 @@ public class ImageMessage extends MessageAssetBase {
                         @JsonProperty("size") long size,
                         @JsonProperty("sha256") byte[] sha256,
                         @JsonProperty("name") String name) {
-        super(messageId, convId, clientId, userId, assetKey, assetToken, otrKey, mimeType, size, sha256, name);
+        super(eventId, messageId, convId, clientId, userId, time, assetKey, assetToken, otrKey, mimeType, size, sha256, name);
     }
 
     public ImageMessage(MessageAssetBase base, Messages.Asset.ImageMetaData image) {
@@ -55,8 +58,12 @@ public class ImageMessage extends MessageAssetBase {
         setWidth(image.getWidth());
     }
 
-    public ImageMessage(UUID msgId, UUID convId, String clientId, UUID userId) {
-        super(msgId, convId, clientId, userId);
+    public ImageMessage(UUID eventId, UUID msgId, UUID convId, String clientId, UUID userId, String time) {
+        super(eventId, msgId, convId, clientId, userId, time);
+    }
+
+    public ImageMessage(MessageBase msg) {
+        super(msg);
     }
 
     public int getHeight() {

--- a/src/main/java/com/wire/xenon/models/LinkPreviewMessage.java
+++ b/src/main/java/com/wire/xenon/models/LinkPreviewMessage.java
@@ -22,14 +22,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.waz.model.Messages;
 
 import java.util.UUID;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Deprecated
 public class LinkPreviewMessage extends ImageMessage {
-
     @JsonProperty
     private String summary;
     @JsonProperty
@@ -42,10 +41,12 @@ public class LinkPreviewMessage extends ImageMessage {
     private int urlOffset;
 
     @JsonCreator
-    public LinkPreviewMessage(@JsonProperty("messageId") UUID messageId,
+    public LinkPreviewMessage(@JsonProperty("eventId") UUID eventId,
+                              @JsonProperty("messageId") UUID messageId,
                               @JsonProperty("conversationId") UUID convId,
                               @JsonProperty("clientId") String clientId,
                               @JsonProperty("userId") UUID userId,
+                              @JsonProperty("time") String time,
                               @JsonProperty("assetKey") String assetKey,
                               @JsonProperty("assetToken") String assetToken,
                               @JsonProperty("otrKey") byte[] otrKey,
@@ -53,16 +54,11 @@ public class LinkPreviewMessage extends ImageMessage {
                               @JsonProperty("size") long size,
                               @JsonProperty("sha256") byte[] sha256,
                               @JsonProperty("name") String name) {
-        super(messageId, convId, clientId, userId, assetKey, assetToken, otrKey, mimeType, size, sha256, name);
+        super(eventId, messageId, convId, clientId, userId, time, assetKey, assetToken, otrKey, mimeType, size, sha256, name);
     }
 
-    public LinkPreviewMessage(MessageAssetBase base, Messages.Asset.ImageMetaData image) {
-        super(base, image);
-
-    }
-
-    public LinkPreviewMessage(UUID msgId, UUID convId, String clientId, UUID userId) {
-        super(msgId, convId, clientId, userId);
+    public LinkPreviewMessage(MessageBase msg) {
+        super(msg);
     }
 
     public String getSummary() {

--- a/src/main/java/com/wire/xenon/models/MessageAssetBase.java
+++ b/src/main/java/com/wire/xenon/models/MessageAssetBase.java
@@ -22,9 +22,7 @@ import com.waz.model.Messages;
 
 import java.util.UUID;
 
-/**
- *
- */
+@Deprecated
 public class MessageAssetBase extends MessageBase {
     // Remote data
     private String assetKey;
@@ -37,10 +35,20 @@ public class MessageAssetBase extends MessageBase {
     private String name;
     private long size;
 
-    public MessageAssetBase(UUID msgId, UUID convId, String clientId, UUID userId,
-                            String assetKey, String assetToken, byte[] otrKey, String mimeType, long size,
-                            byte[] sha256, String name) {
-        super(msgId, convId, clientId, userId);
+    public MessageAssetBase(UUID eventId,
+                            UUID msgId,
+                            UUID convId,
+                            String clientId,
+                            UUID userId,
+                            String time,
+                            String assetKey,
+                            String assetToken,
+                            byte[] otrKey,
+                            String mimeType,
+                            long size,
+                            byte[] sha256,
+                            String name) {
+        super(eventId, msgId, convId, clientId, userId, time);
         this.assetKey = assetKey;
         this.assetToken = assetToken;
         this.otrKey = otrKey;
@@ -50,12 +58,12 @@ public class MessageAssetBase extends MessageBase {
         this.name = name;
     }
 
-    public MessageAssetBase(UUID msgId, UUID convId, String clientId, UUID userId) {
-        super(msgId, convId, clientId, userId);
+    public MessageAssetBase(UUID eventID, UUID msgId, UUID convId, String clientId, UUID userId, String time) {
+        super(eventID, msgId, convId, clientId, userId, time);
     }
 
     MessageAssetBase(MessageAssetBase base) {
-        super(base.messageId, base.conversationId, base.clientId, base.userId);
+        super(base.eventId, base.messageId, base.conversationId, base.clientId, base.userId, base.time);
         assetKey = base.assetKey;
         assetToken = base.assetToken;
         otrKey = base.otrKey;
@@ -63,7 +71,10 @@ public class MessageAssetBase extends MessageBase {
         size = base.size;
         sha256 = base.sha256;
         name = base.name;
-        time = base.time;
+    }
+
+    public MessageAssetBase(MessageBase msg) {
+        super(msg);
     }
 
     public void setSize(long size) {

--- a/src/main/java/com/wire/xenon/models/MessageAssetBase.java
+++ b/src/main/java/com/wire/xenon/models/MessageAssetBase.java
@@ -23,15 +23,19 @@ import com.waz.model.Messages;
 import java.util.UUID;
 
 /**
+ *
  */
 public class MessageAssetBase extends MessageBase {
+    // Remote data
     private String assetKey;
     private String assetToken;
     private byte[] otrKey;
-    private String mimeType;
-    private long size;
     private byte[] sha256;
+
+    // Origin
+    private String mimeType;
     private String name;
+    private long size;
 
     public MessageAssetBase(UUID msgId, UUID convId, String clientId, UUID userId,
                             String assetKey, String assetToken, byte[] otrKey, String mimeType, long size,

--- a/src/main/java/com/wire/xenon/models/MessageBase.java
+++ b/src/main/java/com/wire/xenon/models/MessageBase.java
@@ -21,10 +21,11 @@ package com.wire.xenon.models;
 import java.util.UUID;
 
 public abstract class MessageBase {
+    protected final UUID messageId;
+    protected UUID eventId;
     protected final UUID userId;
     protected final String clientId;
     protected final UUID conversationId;
-    protected final UUID messageId;
     protected String time;
 
     MessageBase(UUID msgId, UUID convId, String clientId, UUID userId) {
@@ -56,5 +57,13 @@ public abstract class MessageBase {
 
     public void setTime(String time) {
         this.time = time;
+    }
+
+    public UUID getEventId() {
+        return eventId;
+    }
+
+    public void setEventId(UUID eventId) {
+        this.eventId = eventId;
     }
 }

--- a/src/main/java/com/wire/xenon/models/MessageBase.java
+++ b/src/main/java/com/wire/xenon/models/MessageBase.java
@@ -20,19 +20,30 @@ package com.wire.xenon.models;
 
 import java.util.UUID;
 
-public abstract class MessageBase {
+public class MessageBase {
     protected final UUID messageId;
-    protected UUID eventId;
+    protected final UUID eventId;
     protected final UUID userId;
     protected final String clientId;
     protected final UUID conversationId;
-    protected String time;
+    protected final String time;
 
-    MessageBase(UUID msgId, UUID convId, String clientId, UUID userId) {
+    public MessageBase(UUID eventId, UUID msgId, UUID convId, String clientId, UUID userId, String time) {
+        this.eventId = eventId;
         this.messageId = msgId;
         this.conversationId = convId;
         this.clientId = clientId;
         this.userId = userId;
+        this.time = time;
+    }
+
+    public MessageBase(MessageBase msg) {
+        this.eventId = msg.eventId;
+        this.messageId = msg.messageId;
+        this.conversationId = msg.conversationId;
+        this.clientId = msg.clientId;
+        this.userId = msg.userId;
+        this.time = msg.time;
     }
 
     public UUID getConversationId() {
@@ -55,15 +66,7 @@ public abstract class MessageBase {
         return time;
     }
 
-    public void setTime(String time) {
-        this.time = time;
-    }
-
     public UUID getEventId() {
         return eventId;
-    }
-
-    public void setEventId(UUID eventId) {
-        this.eventId = eventId;
     }
 }

--- a/src/main/java/com/wire/xenon/models/OriginMessage.java
+++ b/src/main/java/com/wire/xenon/models/OriginMessage.java
@@ -18,8 +18,6 @@
 
 package com.wire.xenon.models;
 
-import com.waz.model.Messages;
-
 import java.util.UUID;
 
 public abstract class OriginMessage extends MessageBase {
@@ -27,8 +25,12 @@ public abstract class OriginMessage extends MessageBase {
     private String name;
     private long size;
 
-    public OriginMessage(UUID msgId, UUID convId, String clientId, UUID userId) {
-        super(msgId, convId, clientId, userId);
+    public OriginMessage(UUID eventId, UUID msgId, UUID convId, String clientId, UUID userId, String time) {
+        super(eventId, msgId, convId, clientId, userId, time);
+    }
+
+    public OriginMessage(MessageBase msg) {
+        super(msg);
     }
 
     public long getSize() {
@@ -53,11 +55,5 @@ public abstract class OriginMessage extends MessageBase {
 
     public void setName(String name) {
         this.name = name;
-    }
-
-    public void fromOrigin(Messages.Asset.Original original) {
-        setMimeType(original.getMimeType());
-        setSize(original.getSize());
-        setName(original.hasName() ? original.getName() : null);
     }
 }

--- a/src/main/java/com/wire/xenon/models/OriginMessage.java
+++ b/src/main/java/com/wire/xenon/models/OriginMessage.java
@@ -1,0 +1,63 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+package com.wire.xenon.models;
+
+import com.waz.model.Messages;
+
+import java.util.UUID;
+
+public abstract class OriginMessage extends MessageBase {
+    private String mimeType;
+    private String name;
+    private long size;
+
+    public OriginMessage(UUID msgId, UUID convId, String clientId, UUID userId) {
+        super(msgId, convId, clientId, userId);
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public void setSize(long size) {
+        this.size = size;
+    }
+
+    public String getMimeType() {
+        return mimeType;
+    }
+
+    public void setMimeType(String mimeType) {
+        this.mimeType = mimeType;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void fromOrigin(Messages.Asset.Original original) {
+        setMimeType(original.getMimeType());
+        setSize(original.getSize());
+        setName(original.hasName() ? original.getName() : null);
+    }
+}

--- a/src/main/java/com/wire/xenon/models/PhotoPreviewMessage.java
+++ b/src/main/java/com/wire/xenon/models/PhotoPreviewMessage.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.waz.model.Messages;
 
 import java.util.UUID;
 
@@ -34,16 +35,18 @@ public class PhotoPreviewMessage extends OriginMessage {
     private int width;
 
     @JsonCreator
-    public PhotoPreviewMessage(@JsonProperty("messageId") UUID messageId,
+    public PhotoPreviewMessage(@JsonProperty("eventId") UUID eventId,
+                               @JsonProperty("messageId") UUID messageId,
                                @JsonProperty("conversationId") UUID convId,
                                @JsonProperty("clientId") String clientId,
                                @JsonProperty("userId") UUID userId,
+                               @JsonProperty("time") String time,
                                @JsonProperty("mimeType") String mimeType,
                                @JsonProperty("size") long size,
                                @JsonProperty("name") String name,
                                @JsonProperty("width") int width,
                                @JsonProperty("height") int height) {
-        super(messageId, convId, clientId, userId);
+        super(eventId, messageId, convId, clientId, userId, time);
 
         setMimeType(mimeType);
         setName(name);
@@ -53,8 +56,15 @@ public class PhotoPreviewMessage extends OriginMessage {
         setHeight(height);
     }
 
-    public PhotoPreviewMessage(UUID msgId, UUID convId, String clientId, UUID userId) {
-        super(msgId, convId, clientId, userId);
+    public PhotoPreviewMessage(MessageBase msg, Messages.Asset.Original original) {
+        super(msg);
+
+        setMimeType(original.getMimeType());
+        setSize(original.getSize());
+        setName(original.getName());
+
+        setWidth(original.getImage().getWidth());
+        setHeight(original.getImage().getHeight());
     }
 
     public int getHeight() {

--- a/src/main/java/com/wire/xenon/models/PhotoPreviewMessage.java
+++ b/src/main/java/com/wire/xenon/models/PhotoPreviewMessage.java
@@ -1,0 +1,75 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+package com.wire.xenon.models;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PhotoPreviewMessage extends OriginMessage {
+    @JsonProperty
+    private int height;
+    @JsonProperty
+    private int width;
+
+    @JsonCreator
+    public PhotoPreviewMessage(@JsonProperty("messageId") UUID messageId,
+                               @JsonProperty("conversationId") UUID convId,
+                               @JsonProperty("clientId") String clientId,
+                               @JsonProperty("userId") UUID userId,
+                               @JsonProperty("mimeType") String mimeType,
+                               @JsonProperty("size") long size,
+                               @JsonProperty("name") String name,
+                               @JsonProperty("width") int width,
+                               @JsonProperty("height") int height) {
+        super(messageId, convId, clientId, userId);
+
+        setMimeType(mimeType);
+        setName(name);
+        setSize(size);
+
+        setWidth(width);
+        setHeight(height);
+    }
+
+    public PhotoPreviewMessage(UUID msgId, UUID convId, String clientId, UUID userId) {
+        super(msgId, convId, clientId, userId);
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    public void setHeight(int height) {
+        this.height = height;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public void setWidth(int width) {
+        this.width = width;
+    }
+}

--- a/src/main/java/com/wire/xenon/models/PingMessage.java
+++ b/src/main/java/com/wire/xenon/models/PingMessage.java
@@ -27,10 +27,16 @@ import java.util.UUID;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PingMessage extends MessageBase {
     @JsonCreator
-    public PingMessage(@JsonProperty("messageId") UUID messageId,
+    public PingMessage(@JsonProperty("eventId") UUID eventId,
+                       @JsonProperty("messageId") UUID messageId,
                        @JsonProperty("conversationId") UUID convId,
                        @JsonProperty("clientId") String clientId,
-                       @JsonProperty("userId") UUID userId) {
-        super(messageId, convId, clientId, userId);
+                       @JsonProperty("userId") UUID userId,
+                       @JsonProperty("time") String time) {
+        super(eventId, messageId, convId, clientId, userId, time);
+    }
+
+    public PingMessage(MessageBase msgBase) {
+        super(msgBase);
     }
 }

--- a/src/main/java/com/wire/xenon/models/ReactionMessage.java
+++ b/src/main/java/com/wire/xenon/models/ReactionMessage.java
@@ -33,11 +33,17 @@ public class ReactionMessage extends MessageBase {
     private UUID reactionMessageId;
 
     @JsonCreator
-    public ReactionMessage(@JsonProperty("messageId") UUID messageId,
+    public ReactionMessage(@JsonProperty("eventId") UUID eventId,
+                           @JsonProperty("messageId") UUID messageId,
                            @JsonProperty("conversationId") UUID convId,
                            @JsonProperty("clientId") String clientId,
-                           @JsonProperty("userId") UUID userId) {
-        super(messageId, convId, clientId, userId);
+                           @JsonProperty("userId") UUID userId,
+                           @JsonProperty("time") String time) {
+        super(eventId, messageId, convId, clientId, userId, time);
+    }
+
+    public ReactionMessage(MessageBase msgBase) {
+        super(msgBase);
     }
 
     public String getEmoji() {

--- a/src/main/java/com/wire/xenon/models/RemoteMessage.java
+++ b/src/main/java/com/wire/xenon/models/RemoteMessage.java
@@ -20,6 +20,7 @@ package com.wire.xenon.models;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.waz.model.Messages;
 
 import java.util.UUID;
 
@@ -34,20 +35,31 @@ public class RemoteMessage extends MessageBase {
     private byte[] sha256;
 
     @JsonCreator
-    public RemoteMessage(@JsonProperty("messageId") UUID messageId,
+    public RemoteMessage(@JsonProperty("eventId") UUID eventId,
+                         @JsonProperty("messageId") UUID messageId,
                          @JsonProperty("conversationId") UUID convId,
                          @JsonProperty("clientId") String clientId,
                          @JsonProperty("userId") UUID userId,
+                         @JsonProperty("time") String time,
                          @JsonProperty("assetId") String assetId,
                          @JsonProperty("assetToken") String assetToken,
                          @JsonProperty("otrKey") byte[] otrKey,
                          @JsonProperty("sha256") byte[] sha256) {
-        super(messageId, convId, clientId, userId);
+        super(eventId, messageId, convId, clientId, userId, time);
 
         setAssetId(assetId);
         setAssetToken(assetToken);
         setSha256(sha256);
         setOtrKey(otrKey);
+    }
+
+    public RemoteMessage(MessageBase msg, Messages.Asset.RemoteData uploaded) {
+        super(msg);
+
+        setAssetId(uploaded.getAssetId());
+        setAssetToken(uploaded.getAssetToken());
+        setSha256(uploaded.getSha256().toByteArray());
+        setOtrKey(uploaded.getOtrKey().toByteArray());
     }
 
     public String getAssetToken() {

--- a/src/main/java/com/wire/xenon/models/RemoteMessage.java
+++ b/src/main/java/com/wire/xenon/models/RemoteMessage.java
@@ -1,0 +1,84 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+package com.wire.xenon.models;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.UUID;
+
+public class RemoteMessage extends MessageBase {
+    @JsonProperty
+    private String assetId;
+    @JsonProperty
+    private String assetToken;
+    @JsonProperty
+    private byte[] otrKey;
+    @JsonProperty
+    private byte[] sha256;
+
+    @JsonCreator
+    public RemoteMessage(@JsonProperty("messageId") UUID messageId,
+                         @JsonProperty("conversationId") UUID convId,
+                         @JsonProperty("clientId") String clientId,
+                         @JsonProperty("userId") UUID userId,
+                         @JsonProperty("assetId") String assetId,
+                         @JsonProperty("assetToken") String assetToken,
+                         @JsonProperty("otrKey") byte[] otrKey,
+                         @JsonProperty("sha256") byte[] sha256) {
+        super(messageId, convId, clientId, userId);
+
+        setAssetId(assetId);
+        setAssetToken(assetToken);
+        setSha256(sha256);
+        setOtrKey(otrKey);
+    }
+
+    public String getAssetToken() {
+        return assetToken;
+    }
+
+    public void setAssetToken(String assetToken) {
+        this.assetToken = assetToken;
+    }
+
+    public byte[] getOtrKey() {
+        return otrKey;
+    }
+
+    public void setOtrKey(byte[] otrKey) {
+        this.otrKey = otrKey;
+    }
+
+    public String getAssetId() {
+        return assetId;
+    }
+
+    public void setAssetId(String assetId) {
+        this.assetId = assetId;
+    }
+
+    public byte[] getSha256() {
+        return sha256;
+    }
+
+    public void setSha256(byte[] sha256) {
+        this.sha256 = sha256;
+    }
+}

--- a/src/main/java/com/wire/xenon/models/TextMessage.java
+++ b/src/main/java/com/wire/xenon/models/TextMessage.java
@@ -39,14 +39,20 @@ public class TextMessage extends MessageBase {
     private byte[] quotedMessageSha256;
 
     @JsonProperty
-    private ArrayList<Mention> mentions = new ArrayList<>();
+    private ArrayList<Mention> mentions;
 
     @JsonCreator
-    public TextMessage(@JsonProperty("messageId") UUID messageId,
+    public TextMessage(@JsonProperty("eventId") UUID eventId,
+                       @JsonProperty("messageId") UUID messageId,
                        @JsonProperty("conversationId") UUID convId,
                        @JsonProperty("clientId") String clientId,
-                       @JsonProperty("userId") UUID userId) {
-        super(messageId, convId, clientId, userId);
+                       @JsonProperty("userId") UUID userId,
+                       @JsonProperty("time") String time) {
+        super(eventId, messageId, convId, clientId, userId, time);
+    }
+
+    public TextMessage(MessageBase msg) {
+        super(msg);
     }
 
     public String getText() {
@@ -74,6 +80,9 @@ public class TextMessage extends MessageBase {
     }
 
     public void addMention(String userId, int offset, int len) {
+        if (mentions == null)
+            mentions = new ArrayList<>();
+
         Mention mention = new Mention();
         mention.userId = UUID.fromString(userId);
         mention.offset = offset;

--- a/src/main/java/com/wire/xenon/models/TextMessage.java
+++ b/src/main/java/com/wire/xenon/models/TextMessage.java
@@ -39,7 +39,7 @@ public class TextMessage extends MessageBase {
     private byte[] quotedMessageSha256;
 
     @JsonProperty
-    private ArrayList<Mention> mentions;
+    private final ArrayList<Mention> mentions = new ArrayList<>();
 
     @JsonCreator
     public TextMessage(@JsonProperty("eventId") UUID eventId,
@@ -80,9 +80,6 @@ public class TextMessage extends MessageBase {
     }
 
     public void addMention(String userId, int offset, int len) {
-        if (mentions == null)
-            mentions = new ArrayList<>();
-
         Mention mention = new Mention();
         mention.userId = UUID.fromString(userId);
         mention.offset = offset;

--- a/src/main/java/com/wire/xenon/models/VideoMessage.java
+++ b/src/main/java/com/wire/xenon/models/VideoMessage.java
@@ -26,6 +26,7 @@ import com.waz.model.Messages;
 import java.util.UUID;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Deprecated
 public class VideoMessage extends MessageAssetBase {
     @JsonProperty
     private long duration;
@@ -35,11 +36,13 @@ public class VideoMessage extends MessageAssetBase {
     private int height;
 
     @JsonCreator
-    public VideoMessage(@JsonProperty("messageId") UUID messageId,
+    public VideoMessage(@JsonProperty("eventId") UUID eventId,
+                        @JsonProperty("messageId") UUID messageId,
                         @JsonProperty("conversationId") UUID convId,
                         @JsonProperty("clientId") String clientId,
-                        @JsonProperty("userId") UUID userId) {
-        super(messageId, convId, clientId, userId);
+                        @JsonProperty("userId") UUID userId,
+                        @JsonProperty("time") String time) {
+        super(eventId, messageId, convId, clientId, userId, time);
     }
 
     public VideoMessage(MessageAssetBase base, Messages.Asset.VideoMetaData video) {

--- a/src/main/java/com/wire/xenon/models/VideoPreviewMessage.java
+++ b/src/main/java/com/wire/xenon/models/VideoPreviewMessage.java
@@ -21,6 +21,7 @@ package com.wire.xenon.models;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.waz.model.Messages;
 
 import java.util.UUID;
 
@@ -34,17 +35,20 @@ public class VideoPreviewMessage extends OriginMessage {
     private int height;
 
     @JsonCreator
-    public VideoPreviewMessage(@JsonProperty("messageId") UUID messageId,
-                               @JsonProperty("conversationId") UUID convId,
-                               @JsonProperty("clientId") String clientId,
-                               @JsonProperty("userId") UUID userId,
-                               @JsonProperty("mimeType") String mimeType,
-                               @JsonProperty("size") long size,
-                               @JsonProperty("name") String name,
-                               @JsonProperty("width") int width,
-                               @JsonProperty("height") int height,
-                               @JsonProperty("duration") long duration) {
-        super(messageId, convId, clientId, userId);
+    public VideoPreviewMessage(
+            @JsonProperty("eventId") UUID eventId,
+            @JsonProperty("messageId") UUID messageId,
+            @JsonProperty("conversationId") UUID convId,
+            @JsonProperty("clientId") String clientId,
+            @JsonProperty("userId") UUID userId,
+            @JsonProperty("time") String time,
+            @JsonProperty("mimeType") String mimeType,
+            @JsonProperty("size") long size,
+            @JsonProperty("name") String name,
+            @JsonProperty("width") int width,
+            @JsonProperty("height") int height,
+            @JsonProperty("duration") long duration) {
+        super(eventId, messageId, convId, clientId, userId, time);
 
         setMimeType(mimeType);
         setName(name);
@@ -53,6 +57,18 @@ public class VideoPreviewMessage extends OriginMessage {
         setWidth(width);
         setHeight(height);
         setDuration(duration);
+    }
+
+    public VideoPreviewMessage(MessageBase msg, Messages.Asset.Original original) {
+        super(msg);
+
+        setMimeType(original.getMimeType());
+        setSize(original.getSize());
+        setName(original.getName());
+
+        setWidth(original.getVideo().getWidth());
+        setHeight(original.getVideo().getHeight());
+        setDuration(original.getVideo().getDurationInMillis());
     }
 
     public long getDuration() {

--- a/src/main/java/com/wire/xenon/models/VideoPreviewMessage.java
+++ b/src/main/java/com/wire/xenon/models/VideoPreviewMessage.java
@@ -1,0 +1,81 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+package com.wire.xenon.models;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class VideoPreviewMessage extends OriginMessage {
+    @JsonProperty
+    private long duration;
+    @JsonProperty
+    private int width;
+    @JsonProperty
+    private int height;
+
+    @JsonCreator
+    public VideoPreviewMessage(@JsonProperty("messageId") UUID messageId,
+                               @JsonProperty("conversationId") UUID convId,
+                               @JsonProperty("clientId") String clientId,
+                               @JsonProperty("userId") UUID userId,
+                               @JsonProperty("mimeType") String mimeType,
+                               @JsonProperty("size") long size,
+                               @JsonProperty("name") String name,
+                               @JsonProperty("width") int width,
+                               @JsonProperty("height") int height,
+                               @JsonProperty("duration") long duration) {
+        super(messageId, convId, clientId, userId);
+
+        setMimeType(mimeType);
+        setName(name);
+        setSize(size);
+
+        setWidth(width);
+        setHeight(height);
+        setDuration(duration);
+    }
+
+    public long getDuration() {
+        return duration;
+    }
+
+    public void setDuration(long duration) {
+        this.duration = duration;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    public void setHeight(int height) {
+        this.height = height;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public void setWidth(int width) {
+        this.width = width;
+    }
+}

--- a/src/main/java/com/wire/xenon/state/StatesDAO.java
+++ b/src/main/java/com/wire/xenon/state/StatesDAO.java
@@ -7,7 +7,9 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import java.util.UUID;
 
 public interface StatesDAO {
-    @SqlUpdate("INSERT INTO States (botId, bot) VALUES (:botId, to_json(:bot::json)) ON CONFLICT (botId) DO UPDATE SET bot = EXCLUDED.bot")
+    @SqlUpdate("INSERT INTO States (botId, bot) " +
+            "VALUES (:botId, to_json(:bot::json)) " +
+            "ON CONFLICT (botId) DO UPDATE SET bot = EXCLUDED.bot")
     int insert(@Bind("botId") UUID botId,
                @Bind("bot") String bot);
 

--- a/src/test/java/com/wire/xenon/GenericMessageProcessorTest.java
+++ b/src/test/java/com/wire/xenon/GenericMessageProcessorTest.java
@@ -1,0 +1,166 @@
+package com.wire.xenon;
+
+import com.google.protobuf.ByteString;
+import com.waz.model.Messages;
+import com.wire.xenon.backend.GenericMessageProcessor;
+import com.wire.xenon.models.AudioMessage;
+import com.wire.xenon.models.LinkPreviewMessage;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+import java.util.Random;
+import java.util.UUID;
+
+public class GenericMessageProcessorTest {
+
+    public static final String AUDIO_MIME_TYPE = "audio/x-m4a";
+    public static final String NAME = "audio.m4a";
+    public static final int DURATION = 27000;
+    private static final String TITLE = "title";
+    private static final String SUMMARY = "summary";
+    private static final String URL = "https://wire.com";
+    private static final String CONTENT = "This is https://wire.com";
+    private static final int URL_OFFSET = 8;
+    private static final String ASSET_KEY = "key";
+    private static final String ASSET_TOKEN = "token";
+    private static final int HEIGHT = 43;
+    private static final int WIDTH = 84;
+    private static final int SIZE = 123;
+    private static final String MIME_TYPE = "image/png";
+
+    @Test
+    public void testLinkPreview() {
+        MessageHandler handler = new MessageHandler();
+        GenericMessageProcessor processor = new GenericMessageProcessor(null, handler);
+
+        UUID eventId = UUID.randomUUID();
+        UUID messageId = UUID.randomUUID();
+        UUID from = UUID.randomUUID();
+        UUID convId = UUID.randomUUID();
+        String sender = UUID.randomUUID().toString();
+        String time = new Date().toString();
+
+        Messages.Asset.ImageMetaData.Builder image = Messages.Asset.ImageMetaData.newBuilder()
+                .setHeight(HEIGHT)
+                .setWidth(WIDTH);
+
+        Messages.Asset.Original.Builder original = Messages.Asset.Original.newBuilder()
+                .setSize(SIZE)
+                .setMimeType(MIME_TYPE)
+                .setImage(image);
+
+        Messages.Asset.RemoteData.Builder uploaded = Messages.Asset.RemoteData.newBuilder()
+                .setAssetId(ASSET_KEY)
+                .setAssetToken(ASSET_TOKEN)
+                .setOtrKey(ByteString.EMPTY)
+                .setSha256(ByteString.EMPTY);
+
+        Messages.Asset.Builder asset = Messages.Asset.newBuilder()
+                .setOriginal(original)
+                .setUploaded(uploaded);
+
+        Messages.LinkPreview.Builder linkPreview = Messages.LinkPreview.newBuilder()
+                .setTitle(TITLE)
+                .setSummary(SUMMARY)
+                .setUrl(URL)
+                .setUrlOffset(URL_OFFSET)
+                .setImage(asset);
+
+        Messages.Text.Builder text = Messages.Text.newBuilder()
+                .setContent(CONTENT)
+                .addLinkPreview(linkPreview);
+
+        Messages.GenericMessage.Builder builder = Messages.GenericMessage.newBuilder()
+                .setMessageId(messageId.toString())
+                .setText(text);
+
+        processor.process(eventId, from, sender, convId, time, builder.build());
+    }
+
+    @Test
+    public void testAudioOrigin() {
+        MessageHandler handler = new MessageHandler();
+        GenericMessageProcessor processor = new GenericMessageProcessor(null, handler);
+
+        UUID eventId = UUID.randomUUID();
+        UUID messageId = UUID.randomUUID();
+        UUID from = UUID.randomUUID();
+        UUID convId = UUID.randomUUID();
+        String sender = UUID.randomUUID().toString();
+        String time = new Date().toString();
+        byte[] levels = new byte[100];
+        new Random().nextBytes(levels);
+
+        Messages.Asset.AudioMetaData.Builder audioMeta = Messages.Asset.AudioMetaData.newBuilder()
+                .setDurationInMillis(DURATION)
+                .setNormalizedLoudness(ByteString.copyFrom(levels));
+
+        Messages.Asset.Original.Builder original = Messages.Asset.Original.newBuilder()
+                .setSize(SIZE)
+                .setName(NAME)
+                .setMimeType(AUDIO_MIME_TYPE)
+                .setAudio(audioMeta);
+
+        Messages.Asset.Builder asset = Messages.Asset.newBuilder()
+                .setOriginal(original);
+
+        Messages.GenericMessage.Builder builder = Messages.GenericMessage.newBuilder()
+                .setMessageId(messageId.toString())
+                .setAsset(asset);
+
+        processor.process(eventId, from, sender, convId, time, builder.build());
+    }
+
+    @Test
+    public void testAudioUploaded() {
+        MessageHandler handler = new MessageHandler();
+        GenericMessageProcessor processor = new GenericMessageProcessor(null, handler);
+
+        UUID eventId = UUID.randomUUID();
+        UUID messageId = UUID.randomUUID();
+        UUID from = UUID.randomUUID();
+        UUID convId = UUID.randomUUID();
+        String sender = UUID.randomUUID().toString();
+        String time = new Date().toString();
+        byte[] levels = new byte[100];
+        new Random().nextBytes(levels);
+
+        Messages.Asset.RemoteData.Builder uploaded = Messages.Asset.RemoteData.newBuilder()
+                .setAssetId(ASSET_KEY)
+                .setAssetToken(ASSET_TOKEN)
+                .setOtrKey(ByteString.EMPTY)
+                .setSha256(ByteString.EMPTY);
+
+        Messages.Asset.Builder asset = Messages.Asset.newBuilder()
+                .setUploaded(uploaded);
+
+        Messages.GenericMessage.Builder builder = Messages.GenericMessage.newBuilder()
+                .setMessageId(messageId.toString())
+                .setAsset(asset);
+
+        processor.process(eventId, from, sender, convId, time, builder.build());
+    }
+
+    private static class MessageHandler extends MessageHandlerBase {
+        @Override
+        public void onLinkPreview(WireClient client, LinkPreviewMessage msg) {
+            assert msg.getTitle().equals(TITLE);
+            assert msg.getSummary().equals(SUMMARY);
+            assert msg.getUrl().equals(URL);
+            assert msg.getText().equals(CONTENT);
+            assert msg.getUrlOffset() == URL_OFFSET;
+
+            assert msg.getAssetKey().equals(ASSET_KEY);
+            assert msg.getWidth() == WIDTH;
+            assert msg.getHeight() == HEIGHT;
+            assert msg.getSize() == SIZE;
+            assert msg.getMimeType().equals(MIME_TYPE);
+            assert msg.getAssetToken().equals(ASSET_TOKEN);
+        }
+
+        @Override
+        public void onAudio(WireClient client, AudioMessage msg) {
+            assert msg.getMimeType().equals(AUDIO_MIME_TYPE);
+        }
+    }
+}

--- a/src/test/java/com/wire/xenon/GenericMessageProcessorTest.java
+++ b/src/test/java/com/wire/xenon/GenericMessageProcessorTest.java
@@ -5,6 +5,7 @@ import com.waz.model.Messages;
 import com.wire.xenon.backend.GenericMessageProcessor;
 import com.wire.xenon.models.AudioMessage;
 import com.wire.xenon.models.LinkPreviewMessage;
+import com.wire.xenon.models.MessageBase;
 import org.junit.jupiter.api.Test;
 
 import java.util.Date;
@@ -74,7 +75,8 @@ public class GenericMessageProcessorTest {
                 .setMessageId(messageId.toString())
                 .setText(text);
 
-        processor.process(eventId, from, sender, convId, time, builder.build());
+        MessageBase msgBase = new MessageBase(eventId, messageId, convId, sender, from, time);
+        processor.process(msgBase, builder.build());
     }
 
     @Test
@@ -108,7 +110,8 @@ public class GenericMessageProcessorTest {
                 .setMessageId(messageId.toString())
                 .setAsset(asset);
 
-        processor.process(eventId, from, sender, convId, time, builder.build());
+        MessageBase msgBase = new MessageBase(eventId, messageId, convId, sender, from, time);
+        processor.process(msgBase, builder.build());
     }
 
     @Test
@@ -138,7 +141,8 @@ public class GenericMessageProcessorTest {
                 .setMessageId(messageId.toString())
                 .setAsset(asset);
 
-        processor.process(eventId, from, sender, convId, time, builder.build());
+        MessageBase msgBase = new MessageBase(eventId, messageId, convId, sender, from, time);
+        processor.process(msgBase, builder.build());
     }
 
     private static class MessageHandler extends MessageHandlerBase {


### PR DESCRIPTION
I removed message grouping for assets. Let somebody else worries about that. This lib should reflect the API and the API says that preview and remote data are decoupled and come in 2 separate messages (with the same messageId. jfc)
Old API is still in place but should be deprecated. 