### PR TITLE
fix(qualified-id-deserialization) Fix wrong json field in QualifiedId

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.wire</groupId>
     <artifactId>xenon</artifactId>
-    <version>1.6.1</version>
+    <version>1.6.2</version>
 
     <name>Xenon</name>
     <description>Base Wire Bots Library</description>

--- a/src/main/java/com/wire/xenon/backend/models/QualifiedId.java
+++ b/src/main/java/com/wire/xenon/backend/models/QualifiedId.java
@@ -54,7 +54,7 @@ public class QualifiedId {
         public QualifiedId deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
             JsonNode node = jp.getCodec().readTree(jp);
             if (node.has("id") && node.has("domain")) {
-                UUID id = UUID.fromString(node.get("name").asText());
+                UUID id = UUID.fromString(node.get("id").asText());
                 String domain = node.get("domain").asText();
                 return new QualifiedId(id, domain);
             } else if (node.isTextual()) {


### PR DESCRIPTION
* Bump to 1.6.2

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Bug in QualifiedId, unable to deserialize correctly from JSON

### Causes (Optional)

Typo in JSON field

### Solutions

Change "name" to "id" in deserialization

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
