### PR TITLE
Handle mls-welcome events, creating necessary data with core-crypto #WPB-12154

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -1,9 +1,9 @@
 name: Release to Maven Central
 
 on:
-  push:
-    tags:
-      - '*'
+  workflow_dispatch:
+  release:
+    types: [ published ]
 
 jobs:
   tests:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.wire</groupId>
     <artifactId>xenon</artifactId>
-    <version>1.7.0</version>
+    <version>1.7.1</version>
 
     <name>Xenon</name>
     <description>Base Wire Bots Library</description>
@@ -116,6 +116,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.14.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>42.7.3</version>
@@ -198,6 +204,12 @@
                 <groupId>org.jetbrains.dokka</groupId>
                 <artifactId>dokka-maven-plugin</artifactId>
                 <version>1.9.20</version>
+                <configuration>
+                    <sourceDirectories>
+                        <dir>${project.basedir}/src/main/java</dir>
+                        <dir>${project.basedir}/src/main/kotlin</dir>
+                    </sourceDirectories>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>compile</phase>

--- a/src/main/java/com/wire/xenon/MessageResourceBase.java
+++ b/src/main/java/com/wire/xenon/MessageResourceBase.java
@@ -80,9 +80,8 @@ public abstract class MessageResourceBase {
                     return;
                 }
 
-                // Check if we still have some prekeys and keyPackages available. Upload them if needed
+                // Check if we still have some prekeys available. Upload them if needed
                 handler.validatePreKeys(client, participants.size());
-                client.checkAndReplenishKeyPackages();
 
                 SystemMessage systemMessage = getSystemMessage(eventId, payload);
                 systemMessage.users = data.userIds;
@@ -117,9 +116,9 @@ public abstract class MessageResourceBase {
                 Logger.debug("conversation.create: bot: %s", botId);
 
                 systemMessage = getSystemMessage(eventId, payload);
-                Integer otherMembers = PREKEYS_DEFAULT_REPLENISH;
+                Integer preKeysUserCount = PREKEYS_DEFAULT_REPLENISH;
                 if (systemMessage.conversation.members != null) {
-                    otherMembers = systemMessage.conversation.members.others.size();
+                    preKeysUserCount = systemMessage.conversation.members.others.size();
                     Member self = new Member();
                     String selfDomain = null;
                     if (systemMessage.conversation.id != null) {
@@ -130,8 +129,11 @@ public abstract class MessageResourceBase {
                 }
 
                 // Check if we still have some prekeys and keyPackages available. Upload them if needed
-                handler.validatePreKeys(client, otherMembers);
-                client.checkAndReplenishKeyPackages();
+                if (systemMessage.conversation.protocol == Conversation.Protocol.PROTEUS)
+                    handler.validatePreKeys(client, preKeysUserCount);
+                else {
+                    client.checkAndReplenishKeyPackages();
+                }
 
                 handler.onNewConversation(client, systemMessage);
                 break;

--- a/src/main/java/com/wire/xenon/WireClient.java
+++ b/src/main/java/com/wire/xenon/WireClient.java
@@ -40,6 +40,9 @@ import java.util.UUID;
  */
 public interface WireClient extends Closeable {
 
+    Integer KEY_PACKAGES_LOWER_THRESHOLD = 10;
+    Integer KEY_PACKAGES_REPLENISH_AMOUNT = 50;
+
     /**
      * Post a generic message into conversation
      *
@@ -172,6 +175,20 @@ public interface WireClient extends Closeable {
      * @param mlsGroupId the MLS groupId of the conversation to join
      */
     void joinMlsConversation(QualifiedId conversationId, String mlsGroupId);
+
+    /**
+     * When a mls-welcome event is received, this method is called to process it.
+     * It will create a MLS conversation record in the local core-crypto storage.
+     * @param welcome base64 encoded welcome message
+     * @return the MLS group id of the conversation
+     */
+    byte[] processWelcomeMessage(String welcome);
+
+    /**
+     * Checks if the number of available key packages is below the threshold and replenishes them if necessary.
+     * NOTE: Will make an API call to publish the new key packages if needed.
+     */
+    void checkAndReplenishKeyPackages();
 
     /**
      * Invoked by the sdk. Called once when the conversation is created

--- a/src/test/java/com/wire/xenon/MlsClientTest.java
+++ b/src/test/java/com/wire/xenon/MlsClientTest.java
@@ -57,9 +57,12 @@ public class MlsClientTest {
 
         // Create a new client and join the conversation
         CryptoMlsClient mlsClient = new CryptoMlsClient(client1, "pwd");
+        assert !mlsClient.conversationExists(groupIdBase64);
         final byte[] commitBundle = mlsClient.createJoinConversationRequest(groupInfo);
         assert commitBundle.length > groupInfo.length;
         mlsClient.markConversationAsJoined(groupIdBase64);
+        assert mlsClient.conversationExists(groupIdBase64);
+
         // Encrypt a message for the joined conversation
         String plainMessage = UUID.randomUUID().toString();
         final byte[] encryptedMessage = mlsClient.encrypt(groupIdBase64, plainMessage.getBytes());
@@ -91,17 +94,22 @@ public class MlsClientTest {
 
         // Create a new client and join the conversation
         CryptoMlsClient mlsClient = new CryptoMlsClient(client1, "pwd");
+        assert !mlsClient.conversationExists(groupIdBase64);
         final byte[] commitBundle = mlsClient.createJoinConversationRequest(groupInfo);
         assert commitBundle.length > groupInfo.length;
         mlsClient.markConversationAsJoined(groupIdBase64);
+        assert mlsClient.conversationExists(groupIdBase64);
 
         // Create a second client and make the first client invite the second one
         String client2 = "bob1_" + UUID.randomUUID();
         CryptoMlsClient mlsClient2 = new CryptoMlsClient(client2, "pwd");
+        assert !mlsClient2.conversationExists(groupIdBase64);
         final List<byte[]> keyPackages = mlsClient2.generateKeyPackages(1);
         final byte[] welcome = mlsClient.addMemberToConversation(groupIdBase64, keyPackages);
         mlsClient.acceptLatestCommit(groupIdBase64);
-        mlsClient2.welcomeMessage(welcome);
+        String welcomeBase64 = new String(Base64.getEncoder().encode(welcome));
+        mlsClient2.processWelcomeMessage(welcomeBase64);
+        assert mlsClient2.conversationExists(groupIdBase64);
 
         // Encrypt a message for the joined conversation
         String plainMessage = UUID.randomUUID().toString();

--- a/src/test/java/com/wire/xenon/WireClientBaseTest.java
+++ b/src/test/java/com/wire/xenon/WireClientBaseTest.java
@@ -1,0 +1,56 @@
+package com.wire.xenon;
+
+import com.wire.xenon.backend.models.NewBot;
+import com.wire.xenon.crypto.mls.CryptoMlsClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.mockito.Mockito.*;
+
+public class WireClientBaseTest {
+    private WireClientBase wireClientBase;
+    private WireAPI mockApi;
+    private CryptoMlsClient mockCryptoMlsClient;
+    private NewBot mockState;
+
+    @BeforeEach
+    public void setUp() {
+        mockApi = mock(WireAPI.class);
+        mockCryptoMlsClient = mock(CryptoMlsClient.class);
+        mockState = mock(NewBot.class);
+        wireClientBase = new WireClientBase(mockApi, null, mockCryptoMlsClient, mockState);
+    }
+
+    @Test
+    public void checkAndReplenishKeyPackages_replenishesWhenBelowThreshold() {
+        when(mockCryptoMlsClient.validKeyPackageCount()).thenReturn(WireClientBase.KEY_PACKAGES_LOWER_THRESHOLD - 5L);
+
+        wireClientBase.checkAndReplenishKeyPackages();
+
+        verify(mockCryptoMlsClient, times(1)).generateKeyPackages(WireClientBase.KEY_PACKAGES_REPLENISH_AMOUNT);
+    }
+
+    @Test
+    public void checkAndReplenishKeyPackages_doesNotReplenishWhenAboveThreshold() {
+        when(mockCryptoMlsClient.validKeyPackageCount()).thenReturn(WireClientBase.KEY_PACKAGES_LOWER_THRESHOLD + 5L);
+
+        wireClientBase.checkAndReplenishKeyPackages();
+
+        verify(mockCryptoMlsClient, never()).generateKeyPackages(anyInt());
+    }
+
+    @Test
+    public void processWelcomeMessage_callsCheckAndReplenishKeyPackages() {
+        String welcomeMessage = "welcomeMessage";
+        byte[] expectedResponse = new byte[]{1, 2, 3};
+
+        when(mockCryptoMlsClient.processWelcomeMessage(welcomeMessage)).thenReturn(expectedResponse);
+        when(mockCryptoMlsClient.validKeyPackageCount()).thenReturn(WireClientBase.KEY_PACKAGES_LOWER_THRESHOLD + 5L);
+
+        byte[] response = wireClientBase.processWelcomeMessage(welcomeMessage);
+
+        verify(mockCryptoMlsClient, times(1)).processWelcomeMessage(welcomeMessage);
+        assertArrayEquals(expectedResponse, response);
+    }
+}


### PR DESCRIPTION
* Process event and check if new keyPackages are needed
* Check if the conversation already exists when joining via commit
* Check for key package replenishment during conversation.create and conversation.member.join
* Add Mockito to test some simple replenishment and welcomeMessage in WireClientBase
* Release on git tag instead of GitHub release, as other projects do
* Fix Dokka not generating JavaDoc for CryptoMlsClient

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

MLS is supported for previous conversations, but not new ones received through mls-welcome event

### Solutions

Add mld-welcome handling

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
