### PR TITLE
feat(remove-mls-data-on-device-removed) #WPB-12155

### DIFF
--- a/src/main/kotlin/com/wire/xenon/crypto/mls/CryptoMlsClient.kt
+++ b/src/main/kotlin/com/wire/xenon/crypto/mls/CryptoMlsClient.kt
@@ -147,20 +147,14 @@ class CryptoMlsClient(private val clientId: String, clientDatabaseKey: String) :
     }
 
     /**
-     * <p>
-     *     This function wipes current client MLS folder
-     * <p>
-     * <p>
-     *     - Closes CoreCrypto
-     *     - Verify if path exists and is a directory
-     *     - Deletes files and folder recursively
-     * <p>
-     * <p>Note(CoreCrypto)</p>
-     * <p>
-     *     There is an issue with `wipe()` function from `CoreCrypto`
-     *     When ticket [WPB-14514] is done we can then update and use it instead of deleting
-     *     the folder ourselves.
-     * </p>
+     * This method wipes current client MLS folder.
+     *
+     * - Closes CoreCrypto
+     * - Verify if path exists and is a directory
+     * - Deletes files and folder recursively
+     *
+     * Note(CoreCrypto): There is an issue with `wipe()` function from `CoreCrypto` when ticket [WPB-14514] is done,
+     * we can then update and use it instead of deleting the folder ourselves.
      */
     fun wipe() {
         this.close()
@@ -176,10 +170,9 @@ class CryptoMlsClient(private val clientId: String, clientDatabaseKey: String) :
 }
 
 /**
- * <p>
- *     Currently used for initializing CoreCrypto, but there is efforts on removing the necessity on newer
- *     versions of CoreCrypto.
- * <p>
+ * Dummy CoreCrypto Callbacks.
+ *
+ * Currently used for initializing CoreCrypto, but there is efforts on removing the necessity on newer versions of CoreCrypto.
  */
 private class CoreCryptoCallbacks : CoreCryptoCallbacks {
 

--- a/src/main/kotlin/com/wire/xenon/crypto/mls/CryptoMlsClient.kt
+++ b/src/main/kotlin/com/wire/xenon/crypto/mls/CryptoMlsClient.kt
@@ -1,8 +1,10 @@
 package com.wire.xenon.crypto.mls
 
+import com.wire.crypto.CoreCrypto
+import com.wire.crypto.CoreCryptoCallbacks
+import com.wire.crypto.client.Ciphersuites
 import com.wire.crypto.client.ClientId
 import com.wire.crypto.client.CommitBundle
-import com.wire.crypto.client.CoreCryptoCentral
 import com.wire.crypto.client.GroupInfo
 import com.wire.crypto.client.MLSClient
 import com.wire.crypto.client.MLSGroupId
@@ -10,31 +12,44 @@ import com.wire.crypto.client.MLSKeyPackage
 import com.wire.crypto.client.MlsMessage
 import com.wire.crypto.client.PlaintextMessage
 import com.wire.crypto.client.Welcome
+import com.wire.crypto.coreCryptoDeferredInit
 import kotlinx.coroutines.runBlocking
 import java.io.Closeable
+import java.io.File
+import java.nio.file.Paths
 import java.util.*
 
-class CryptoMlsClient : Closeable {
-    private var cryptoCentral: CoreCryptoCentral
+class CryptoMlsClient(private val clientId: String, clientDatabaseKey: String) : Closeable {
+    private var coreCrypto: CoreCrypto
     private var mlsClient: MLSClient
-    private val clientId: String
 
-    constructor(clientId: String, clientDatabaseKey: String) {
+    private companion object {
+        private const val KEYSTORE_NAME = "keystore"
+    }
+
+    init {
         runBlocking {
-            cryptoCentral = CoreCryptoCentral.invoke(
-                getDirectoryPath(clientId),
-                clientDatabaseKey)
-            mlsClient = cryptoCentral.mlsClient(ClientId(clientId))
+            val clientDirectoryPath = getDirectoryPath(clientId = clientId)
+            val path = "$clientDirectoryPath/$KEYSTORE_NAME"
+
+            File(clientDirectoryPath).mkdirs()
+
+            coreCrypto = coreCryptoDeferredInit(
+                path = path,
+                key = clientDatabaseKey
+            )
+            coreCrypto.setCallbacks(callbacks = CoreCryptoCallbacks())
+            mlsClient = MLSClient(cc = coreCrypto).apply {
+                mlsInit(id = ClientId(clientId), Ciphersuites.DEFAULT)
+            }
         }
-        this.clientId = clientId
     }
 
     fun getId(): String = clientId
+
     fun getCoreCryptoClient(): MLSClient = mlsClient
 
-    private fun getDirectoryPath(clientId: String): String {
-        return "mls/$clientId"
-    }
+    private fun getDirectoryPath(clientId: String): String = "mls/$clientId"
 
     fun encrypt(mlsGroupId: String, plainMessage: ByteArray): ByteArray? {
         val mlsGroupIdBytes: ByteArray = Base64.getDecoder().decode(mlsGroupId)
@@ -128,6 +143,58 @@ class CryptoMlsClient : Closeable {
     }
 
     override fun close() {
-        runBlocking { cryptoCentral.close() }
+        runBlocking { coreCrypto.close() }
     }
+
+    /**
+     * <p>
+     *     This function wipes current client MLS folder
+     * <p>
+     * <p>
+     *     - Closes CoreCrypto
+     *     - Verify if path exists and is a directory
+     *     - Deletes files and folder recursively
+     * <p>
+     * <p>Note(CoreCrypto)</p>
+     * <p>
+     *     There is an issue with `wipe()` function from `CoreCrypto`
+     *     When ticket [WPB-14514] is done we can then update and use it instead of deleting
+     *     the folder ourselves.
+     * </p>
+     */
+    fun wipe() {
+        this.close()
+        runBlocking {
+            val path = Paths.get(getDirectoryPath(clientId = clientId))
+            val file = path.toFile()
+
+            if (file.exists() && file.isDirectory) {
+                file.deleteRecursively()
+            }
+        }
+    }
+}
+
+/**
+ * <p>
+ *     Currently used for initializing CoreCrypto, but there is efforts on removing the necessity on newer
+ *     versions of CoreCrypto.
+ * <p>
+ */
+private class CoreCryptoCallbacks : CoreCryptoCallbacks {
+
+    override suspend fun authorize(conversationId: ByteArray, clientId: ByteArray): Boolean = true
+
+    override suspend fun userAuthorize(
+        conversationId: ByteArray,
+        externalClientId: ByteArray,
+        existingClients: List<ByteArray>
+    ): Boolean = true
+
+    override suspend fun clientIsExistingGroupUser(
+        conversationId: ByteArray,
+        clientId: ByteArray,
+        existingClients: List<ByteArray>,
+        parentConversationClients: List<ByteArray>?
+    ): Boolean = true
 }

--- a/src/test/java/com/wire/xenon/MlsClientTest.java
+++ b/src/test/java/com/wire/xenon/MlsClientTest.java
@@ -7,6 +7,9 @@ import org.junit.jupiter.api.Test;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.List;
 import java.util.UUID;
@@ -14,6 +17,7 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MlsClientTest {
+
     @Test
     public void testMlsClientInitialization() {
         String client1 = "alice1_" + UUID.randomUUID();
@@ -119,5 +123,23 @@ public class MlsClientTest {
 
         final byte[] decrypted = mlsClient2.decrypt(groupIdBase64, encryptedBase64Message);
         assert new String(decrypted).equals(plainMessage);
+    }
+
+    @Test
+    public void testMlsClientInitializationAndWipe() {
+        // given
+        String client = "wipe_" + UUID.randomUUID();
+        CryptoMlsClient cryptoMlsClient = new CryptoMlsClient(client, "pwd");
+        assert cryptoMlsClient != null;
+
+        Path path = Paths.get("mls/" + client);
+        boolean pathExists = Files.exists(path);
+        assert pathExists;
+
+        // when
+        cryptoMlsClient.wipe();
+
+        // then
+        assert Files.notExists(path);
     }
 }


### PR DESCRIPTION
* Change usage of CoreCryptoCentral to CoreCrypto directly
* Continue with usage of MLSClient (for now)
* Add a new method to wipe client's MLS folder
* Add tests

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

From upper lib usages (Legalhold) there was no way to properly wipe MLS data of removed client.

### Causes (Optional)

Not implemented.

### Solutions

- Change usage from `CoreCryptoCentral` to `CoreCrypto` but keep usage of `MlsClient` just so we don't have to do the full migration (`CoreCryptoCentral` -> `CoreCrypto`) for now.
- Add `wipe()` method to `CryptoMlsClient` that closes the client connection and removes the MLS folder and files

### Testing

#### Test Coverage (Optional)

- [X] I have added automated test to this contribution


### Notes (Optional)

We first thought on using `CoreCrypto` original `wipe()` function, but unfortunately for now there is an issue with the said function so we are doing the wipe ourselves.
When the changes come live from CoreCrypto we can then update and remove our own logic to just call `coreCrypto.wipe()`