### PR TITLE
fix(fully-qualified-client) #WPB-12153

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.wire</groupId>
     <artifactId>xenon</artifactId>
-    <version>1.7.2</version>
+    <version>1.8.0</version>
 
     <name>Xenon</name>
     <description>Base Wire Bots Library</description>

--- a/src/main/java/com/wire/xenon/MessageResourceBase.java
+++ b/src/main/java/com/wire/xenon/MessageResourceBase.java
@@ -71,7 +71,7 @@ public abstract class MessageResourceBase {
 
                 // Check if this bot got added to the conversation
                 List<QualifiedId> participants = data.userIds;
-                if (participants.remove(botId)) {
+                if (participants.remove(new QualifiedId(botId, null))) {
                     SystemMessage systemMessage = getSystemMessage(eventId, payload);
                     systemMessage.conversation = client.getConversation();
                     systemMessage.type = "conversation.create"; //hack the type
@@ -96,7 +96,7 @@ public abstract class MessageResourceBase {
 
                 // Check if this bot got removed from the conversation
                 participants = data.userIds;
-                if (participants.remove(botId)) {
+                if (participants.remove(new QualifiedId(botId, null))) {
                     handler.onBotRemoved(botId, systemMessage);
                     return;
                 }
@@ -183,9 +183,10 @@ public abstract class MessageResourceBase {
         if (payload.data != null) {
             systemMessage.conversation.creator = payload.data.creator;
             systemMessage.conversation.name = payload.data.name;
-            if (payload.data.members != null)
+            if (payload.data.members != null) {
                 systemMessage.conversation.members = new Payload.Members();
                 systemMessage.conversation.members.others = payload.data.members.others;
+            }
         }
 
         return systemMessage;

--- a/src/main/java/com/wire/xenon/backend/models/Payload.java
+++ b/src/main/java/com/wire/xenon/backend/models/Payload.java
@@ -113,7 +113,13 @@ public class Payload {
                     data.sender = node.has("sender") ? node.get("sender").asText() : null;
                     data.recipient = node.has("recipient") ? node.get("recipient").asText() : null;
                     data.text = node.has("text") ? node.get("text").asText() : null;
-                    data.userIds = node.has("qualified_user_ids") ? jp.getCodec().readValue(node.get("qualified_user_ids").traverse(jp.getCodec()), new TypeReference<List<QualifiedId>>() {}): new ArrayList<>();
+                    if (node.has("qualified_user_ids")) {
+                        data.userIds = jp.getCodec().readValue(node.get("qualified_user_ids").traverse(jp.getCodec()), new TypeReference<List<QualifiedId>>() {});
+                    } else if (node.has("user_ids")) {
+                        data.userIds = jp.getCodec().readValue(node.get("user_ids").traverse(jp.getCodec()), new TypeReference<List<QualifiedId>>() {});
+                    } else {
+                        data.userIds = new ArrayList<>();
+                    }
                     data.users = node.has("users") ? jp.getCodec().readValue(node.get("users").traverse(jp.getCodec()), new TypeReference<List<User>>() {}) : new ArrayList<>();
                     data.name = node.has("name") ? node.get("name").asText() : null;
                     data.creator = node.has("creator") && node.get("creator").isTextual() ? UUID.fromString(node.get("creator").asText()) : null;


### PR DESCRIPTION
* Add userId to MLS client init, allowing to push key packages
* Fix deserialization errors of qualified_user_ids and conversation.members
* Bump to 1.8.0

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

MLS clients were created but having just the clientId meant that they could not publish key packages, rendering them useless

### Solutions

Add userId to MLS client init

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
