### PR TITLE
feat(set and use any mls ciphersuite) #WPB-14877

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.wire</groupId>
     <artifactId>xenon</artifactId>
-    <version>1.8.0</version>
+    <version>1.8.1</version>
 
     <name>Xenon</name>
     <description>Base Wire Bots Library</description>

--- a/src/main/java/com/wire/xenon/WireAPI.java
+++ b/src/main/java/com/wire/xenon/WireAPI.java
@@ -2,10 +2,7 @@ package com.wire.xenon;
 
 import com.wire.xenon.assets.IAsset;
 import com.wire.xenon.backend.KeyPackageUpdate;
-import com.wire.xenon.backend.models.ClientUpdate;
-import com.wire.xenon.backend.models.Conversation;
-import com.wire.xenon.backend.models.QualifiedId;
-import com.wire.xenon.backend.models.User;
+import com.wire.xenon.backend.models.*;
 import com.wire.xenon.exceptions.HttpException;
 import com.wire.xenon.models.AssetKey;
 import com.wire.xenon.models.otr.*;
@@ -56,15 +53,15 @@ public interface WireAPI {
 
     void acceptConnection(QualifiedId user) throws Exception;
 
-    boolean isMlsEnabled(); // Calls GET /mls/public-keys and GET /feature-configs, checking if MLS is enabled on the backend
+    FeatureConfig getFeatureConfig();
 
-    void uploadClientPublicKey(String clientId, ClientUpdate clientUpdate); // Calls PUT /clients/{clientId}
+    void uploadClientPublicKey(String clientId, ClientUpdate clientUpdate);
 
-    void uploadClientKeyPackages(String clientId, KeyPackageUpdate keyPackageUpdate); // Calls POST /mls/key-packages/self/{client}
+    void uploadClientKeyPackages(String clientId, KeyPackageUpdate keyPackageUpdate);
 
-    byte[] getConversationGroupInfo(QualifiedId conversationId); // Calls GET /conversations/{cnv_domain}/{cnv}/groupinfo returns a response with type message/mls, should be returned as byte array
+    byte[] getConversationGroupInfo(QualifiedId conversationId);
 
-    void commitMlsBundle(byte[] commitBundle); // Calls POST /mls/commit-bundles, we care only if it is successful, no need to return anything
+    void commitMlsBundle(byte[] commitBundle);
 
-    List<Conversation> getUserConversations(); // Calls POST /conversations/list-ids (paginated) to get all the user's id, then calls POST /conversations/list passing the ids. Returns lists of conversations
+    List<Conversation> getUserConversations();
 }

--- a/src/main/java/com/wire/xenon/WireClient.java
+++ b/src/main/java/com/wire/xenon/WireClient.java
@@ -226,13 +226,6 @@ public interface WireClient extends Closeable {
     ArrayList<Integer> getAvailablePrekeys();
 
     /**
-     * Checks if CryptoBox is closed
-     *
-     * @return True if crypto box is closed
-     */
-    boolean isClosed();
-
-    /**
      * Download publicly available profile picture for the given asset key. This asset is not encrypted
      *
      * @param assetKey Unique asset identifier (String)

--- a/src/main/java/com/wire/xenon/WireClientBase.java
+++ b/src/main/java/com/wire/xenon/WireClientBase.java
@@ -58,14 +58,12 @@ public class WireClientBase implements WireClient {
 
     @Override
     public void close() throws IOException {
-        crypto.close();
-        cryptoMlsClient.close();
-    }
-
-    @Override
-    public boolean isClosed() {
-        // This method is unused, no need to add Core-Crypto handling.
-        return crypto.isClosed();
+        if (crypto != null) {
+            crypto.close();
+        }
+        if (cryptoMlsClient != null) {
+            cryptoMlsClient.close();
+        }
     }
 
     /**

--- a/src/main/java/com/wire/xenon/backend/models/FeatureConfig.java
+++ b/src/main/java/com/wire/xenon/backend/models/FeatureConfig.java
@@ -1,0 +1,19 @@
+package com.wire.xenon.backend.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class FeatureConfig {
+
+    @JsonProperty("mls")
+    public MlsResponse mls;
+
+    public static FeatureConfig disabledMls() {
+        FeatureConfig featureConfig = new FeatureConfig();
+        featureConfig.mls = MlsResponse.disabledMlsResponse();
+        return featureConfig;
+    }
+}

--- a/src/main/java/com/wire/xenon/backend/models/MlsConfigResponse.java
+++ b/src/main/java/com/wire/xenon/backend/models/MlsConfigResponse.java
@@ -1,0 +1,23 @@
+package com.wire.xenon.backend.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MlsConfigResponse {
+    @JsonProperty
+    public List<Integer> allowedCipherSuites;
+
+    @JsonProperty
+    public Integer defaultCipherSuite;
+
+    @JsonProperty
+    public String defaultProtocol;
+
+    @JsonProperty
+    public List<String> supportedProtocols;
+}

--- a/src/main/java/com/wire/xenon/backend/models/MlsResponse.java
+++ b/src/main/java/com/wire/xenon/backend/models/MlsResponse.java
@@ -1,0 +1,25 @@
+package com.wire.xenon.backend.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MlsResponse {
+    @JsonProperty("config")
+    public MlsConfigResponse config;
+
+    @JsonProperty
+    public String status;
+
+    public static MlsResponse disabledMlsResponse() {
+        MlsResponse mlsResponse = new MlsResponse();
+        mlsResponse.status = "disabled";
+        return mlsResponse;
+    }
+
+    public boolean isMlsStatusEnabled() {
+        return status != null && status.equals("enabled");
+    }
+}

--- a/src/test/java/com/wire/xenon/MlsClientTest.java
+++ b/src/test/java/com/wire/xenon/MlsClientTest.java
@@ -23,11 +23,11 @@ public class MlsClientTest {
     public void testMlsClientInitialization() {
         QualifiedId user1 = new QualifiedId(UUID.randomUUID(), "wire.com");
         String client1 = "alice1_" + UUID.randomUUID();
-        CryptoMlsClient mlsClient = new CryptoMlsClient(client1, user1, "pwd");
+        CryptoMlsClient mlsClient = new CryptoMlsClient(client1, user1, 2, "pwd");
         assert mlsClient != null;
         mlsClient.close();
 
-        CryptoMlsClient mlsSameClient = new CryptoMlsClient(client1, user1, "pwd");
+        CryptoMlsClient mlsSameClient = new CryptoMlsClient(client1, user1, 2,  "pwd");
         assert mlsSameClient != null;
         assert mlsSameClient.getId().equals(mlsClient.getId());
 
@@ -100,7 +100,7 @@ public class MlsClientTest {
         byte[] groupInfo = inputStream.readAllBytes();
 
         // Create a new client and join the conversation
-        CryptoMlsClient mlsClient = new CryptoMlsClient(client1, user1, "pwd");
+        CryptoMlsClient mlsClient = new CryptoMlsClient(client1, user1, 1, "pwd");
         assert !mlsClient.conversationExists(groupIdBase64);
         final byte[] commitBundle = mlsClient.createJoinConversationRequest(groupInfo);
         assert commitBundle.length > groupInfo.length;
@@ -110,7 +110,7 @@ public class MlsClientTest {
         // Create a second client and make the first client invite the second one
         QualifiedId user2 = new QualifiedId(UUID.randomUUID(), "wire.com");
         String client2 = "bob1_" + UUID.randomUUID();
-        CryptoMlsClient mlsClient2 = new CryptoMlsClient(client2, user2, "pwd");
+        CryptoMlsClient mlsClient2 = new CryptoMlsClient(client2, user2, 1, "pwd");
         assert !mlsClient2.conversationExists(groupIdBase64);
         final List<byte[]> keyPackages = mlsClient2.generateKeyPackages(1);
         final byte[] welcome = mlsClient.addMemberToConversation(groupIdBase64, keyPackages);


### PR DESCRIPTION
* Adapt to set and use in all calls any ciphersuite instead of only the default one
* Change API contract of isMlsEnabled, now returning the full FeatureConfig
* Move some MLS response DTO from Helium
* Bump to 1.8.1

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

MLS client only used the default ciphersuite

### Causes (Optional)

Possible issues on backend that supported other ciphersuites

### Solutions

Allow any of the supported ciphersuite to be added on client creation and use it in required operations

#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
