### PR TITLE
feat(adjust-mls-public-key-signature-based-on-ciphersuite) #WPB-16405

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.wire</groupId>
     <artifactId>xenon</artifactId>
-    <version>1.8.1</version>
+    <version>1.8.2</version>
 
     <name>Xenon</name>
     <description>Base Wire Bots Library</description>

--- a/src/main/java/com/wire/xenon/WireClientBase.java
+++ b/src/main/java/com/wire/xenon/WireClientBase.java
@@ -1,6 +1,7 @@
 package com.wire.xenon;
 
 import com.wire.bots.cryptobox.CryptoException;
+import com.wire.crypto.client.Ciphersuite;
 import com.wire.xenon.assets.IAsset;
 import com.wire.xenon.assets.IGeneric;
 import com.wire.xenon.backend.KeyPackageUpdate;
@@ -211,11 +212,8 @@ public class WireClientBase implements WireClient {
 
     @Override
     public void updateClientWithMlsPublicKey() {
-        final byte[] publicKey = cryptoMlsClient.getPublicKey();
-        ClientUpdate.MlsPublicKeys mlsPublicKeys = new ClientUpdate.MlsPublicKeys();
-        mlsPublicKeys.ed25519 = Base64.getEncoder().encodeToString(publicKey);
         ClientUpdate clientUpdate = new ClientUpdate();
-        clientUpdate.mlsPublicKeys = mlsPublicKeys;
+        clientUpdate.mlsPublicKeys = cryptoMlsClient.getPublicKeysToUpload();
 
         api.uploadClientPublicKey(cryptoMlsClient.getId(), clientUpdate);
     }

--- a/src/main/java/com/wire/xenon/backend/models/ClientUpdate.java
+++ b/src/main/java/com/wire/xenon/backend/models/ClientUpdate.java
@@ -18,6 +18,7 @@
 
 package com.wire.xenon.backend.models;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -36,7 +37,8 @@ public class ClientUpdate {
         @JsonProperty("ecdsa_secp384r1_sha384")
         public String ecdsaSecp384r1Sha384;
         @JsonProperty("ecdsa_secp521r1_sha512")
-        public String ecdsaSecp521r1Sha512;
+        @JsonAlias("ecdsa_secp521r1_sha521")
+        public String ecdsaSecp521r1Sha521;
         @JsonProperty("ed25519")
         public String ed25519;
     }


### PR DESCRIPTION
* Bump Xenon version to 1.8.2
* Add `getPublicKeysToUpload` into CryptoMlsClient to handle possible MlsPublicKey returns
* Remove encoding of default public key as the logic is now being done in CryptoMlsClient
* Add JSON type alias for `ecdsa_secp521r1_sha521`

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [X] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [X] contains a reference JIRA issue number like `SQPIT-764`
  - [X] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [X] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Only the default Public MLS Key was being used.

### Solutions

Handle different MLS Public Keys based on received Ciphersuite
